### PR TITLE
Feature/enhance provide and refresh endpoints

### DIFF
--- a/controllers/api.go
+++ b/controllers/api.go
@@ -58,6 +58,7 @@ func (api API) FillCSV(c *gin.Context) {
 //RefreshCache feeds the csv data and save in redis
 func (api API) RefreshCache(c *gin.Context) {
 	if err := api.Refresh(c); err != nil {
+		c.Error(err)
 		c.Status(http.StatusInternalServerError)
 		return
 	}

--- a/controllers/api.go
+++ b/controllers/api.go
@@ -21,7 +21,7 @@ func NewAPI(fetcher fetcher, refresher refresher, getter getter) API {
 }
 
 type fetcher interface {
-	Fetch(from, to int) error
+	Fetch(ctx context.Context, from, to int) error
 }
 
 type refresher interface {
@@ -46,7 +46,7 @@ func (api API) FillCSV(c *gin.Context) {
 		return
 	}
 
-	if err := api.Fetch(requestBody.From, requestBody.To); err != nil {
+	if err := api.Fetch(c, requestBody.From, requestBody.To); err != nil {
 		c.Status(http.StatusInternalServerError)
 		fmt.Println(err)
 		return

--- a/repositories/local_storage.go
+++ b/repositories/local_storage.go
@@ -34,27 +34,6 @@ func (l LocalStorage) Write(pokemons []models.Pokemon) error {
 	return nil
 }
 
-func (l LocalStorage) ReadOld() ([]models.Pokemon, error) {
-	file, fErr := os.Open(filePath)
-	defer file.Close()
-	if fErr != nil {
-		return nil, fErr
-	}
-
-	r := csv.NewReader(file)
-	records, rErr := r.ReadAll()
-	if rErr != nil {
-		return nil, rErr
-	}
-
-	pokemons, err := parseCSVData(records)
-	if err != nil {
-		return nil, err
-	}
-
-	return pokemons, nil
-}
-
 func (l LocalStorage) Read(ctx context.Context, cancel context.CancelFunc) chan models.Pokemon {
 	in := generateLines(ctx, cancel)
 
@@ -182,41 +161,4 @@ func buildRecords(pokemons []models.Pokemon) [][]string {
 	}
 
 	return records
-}
-
-func parseCSVData(records [][]string) ([]models.Pokemon, error) {
-	var pokemons []models.Pokemon
-	for i, record := range records {
-		if i == 0 {
-			continue
-		}
-
-		id, err := strconv.Atoi(record[0])
-		if err != nil {
-			return nil, err
-		}
-
-		height, err := strconv.Atoi(record[2])
-		if err != nil {
-			return nil, err
-		}
-
-		weight, err := strconv.Atoi(record[3])
-		if err != nil {
-			return nil, err
-		}
-
-		pokemon := models.Pokemon{
-			ID:              id,
-			Name:            record[1],
-			Height:          height,
-			Weight:          weight,
-			Abilities:       nil,
-			FlatAbilityURLs: record[4],
-			EffectEntries:   nil,
-		}
-		pokemons = append(pokemons, pokemon)
-	}
-
-	return pokemons, nil
 }

--- a/use_cases/fetcher.go
+++ b/use_cases/fetcher.go
@@ -1,9 +1,11 @@
 package use_cases
 
 import (
+	"context"
 	"log"
 	"strings"
 	"sync"
+	"time"
 
 	"GoConcurrency-Bootcamp-2022/models"
 )
@@ -25,8 +27,8 @@ func NewFetcher(api api, storage writer) Fetcher {
 	return Fetcher{api, storage}
 }
 
-func (f Fetcher) Fetch(from, to int) error {
-	pokeChannel := f.generatePokeStream(from, to)
+func (f Fetcher) Fetch(ctx context.Context, from, to int) error {
+	pokeChannel := f.generatePokeStream(ctx, from, to)
 
 	var pokemons []models.Pokemon
 	for pokemon := range pokeChannel {
@@ -42,24 +44,46 @@ func (f Fetcher) Fetch(from, to int) error {
 	return f.storage.Write(pokemons)
 }
 
-func (f Fetcher) generatePokeStream(from, to int) chan models.Pokemon {
+func (f Fetcher) generatePokeStream(ctx context.Context, from, to int) chan models.Pokemon {
+	ctx, cancelFn := context.WithCancel(ctx)
 	ch := make(chan models.Pokemon)
 	wg := sync.WaitGroup{}
 
-	for id := from; id <= to; id++ {
-		wg.Add(1)
+	wg.Add(1)
+	go func(ctx context.Context, cancelFn context.CancelFunc) {
+		defer wg.Done()
 
-		go func(id int) {
-			defer wg.Done()
-
-			pokemon, err := f.api.FetchPokemon(id)
-			if err != nil {
-				log.Printf("cannot get id: %d, due to err: %v", id, err)
+		for id := from; id <= to; id++ {
+			if ctx.Err() != nil {
+				log.Printf("breaking 'For' statement from: %d in order to avoid performing unnecessary goroutines", id)
+				return
 			}
 
-			ch <- pokemon
-		}(id)
-	}
+			if id > 1000 {
+				time.Sleep(time.Duration(100) * time.Millisecond)
+			}
+
+			wg.Add(1)
+			go func(ctx context.Context, cancelFn context.CancelFunc, id int) {
+				defer wg.Done()
+				time.Sleep(time.Duration(100+id) * time.Millisecond)
+
+				if ctx.Err() != nil {
+					log.Printf("breaking goroutine (#%d) process due to invalid context: %v\n", id, ctx.Err())
+					return
+				}
+
+				pokemon, err := f.api.FetchPokemon(id)
+				if err != nil {
+					log.Printf("cannot get id: %d, due to err: %v\n", id, err)
+					cancelFn()
+				}
+				ch <- pokemon
+
+			}(ctx, cancelFn, id)
+
+		}
+	}(ctx, cancelFn)
 
 	go func() {
 		wg.Wait()

--- a/use_cases/fetcher.go
+++ b/use_cases/fetcher.go
@@ -1,7 +1,9 @@
 package use_cases
 
 import (
+	"log"
 	"strings"
+	"sync"
 
 	"GoConcurrency-Bootcamp-2022/models"
 )
@@ -24,13 +26,10 @@ func NewFetcher(api api, storage writer) Fetcher {
 }
 
 func (f Fetcher) Fetch(from, to int) error {
-	var pokemons []models.Pokemon
-	for id := from; id <= to; id++ {
-		pokemon, err := f.api.FetchPokemon(id)
-		if err != nil {
-			return err
-		}
+	pokeChannel := f.generatePokeStream(from, to)
 
+	var pokemons []models.Pokemon
+	for pokemon := range pokeChannel {
 		var flatAbilities []string
 		for _, t := range pokemon.Abilities {
 			flatAbilities = append(flatAbilities, t.Ability.URL)
@@ -41,4 +40,31 @@ func (f Fetcher) Fetch(from, to int) error {
 	}
 
 	return f.storage.Write(pokemons)
+}
+
+func (f Fetcher) generatePokeStream(from, to int) chan models.Pokemon {
+	ch := make(chan models.Pokemon)
+	wg := sync.WaitGroup{}
+
+	for id := from; id <= to; id++ {
+		wg.Add(1)
+
+		go func(id int) {
+			defer wg.Done()
+
+			pokemon, err := f.api.FetchPokemon(id)
+			if err != nil {
+				log.Printf("cannot get id: %d, due to err: %v", id, err)
+			}
+
+			ch <- pokemon
+		}(id)
+	}
+
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	return ch
 }

--- a/use_cases/fetcher.go
+++ b/use_cases/fetcher.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"strings"
 	"sync"
-	"time"
 
 	"GoConcurrency-Bootcamp-2022/models"
 )
@@ -59,14 +58,9 @@ func (f Fetcher) generatePokeStream(ctx context.Context, from, to int) chan mode
 				return
 			}
 
-			if id > 1000 {
-				time.Sleep(time.Duration(100) * time.Millisecond)
-			}
-
 			wg.Add(1)
 			go func(ctx context.Context, cancelFn context.CancelFunc, id int) {
 				defer wg.Done()
-				time.Sleep(time.Duration(100+id) * time.Millisecond)
 
 				if ctx.Err() != nil {
 					log.Printf("breaking goroutine (#%d) process due to invalid context: %v\n", id, ctx.Err())

--- a/use_cases/refresher.go
+++ b/use_cases/refresher.go
@@ -2,13 +2,16 @@ package use_cases
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"strings"
+	"sync"
 
 	"GoConcurrency-Bootcamp-2022/models"
 )
 
 type reader interface {
-	Read() ([]models.Pokemon, error)
+	Read(ctx context.Context, cancel context.CancelFunc) chan models.Pokemon
 }
 
 type saver interface {
@@ -30,31 +33,60 @@ func NewRefresher(reader reader, saver saver, fetcher fetcher) Refresher {
 }
 
 func (r Refresher) Refresh(ctx context.Context) error {
-	pokemons, err := r.Read()
+	ctx, cancel := context.WithCancel(ctx)
+	pokemonStream := r.Read(ctx, cancel)
+
+	pokemons, err := r.fanOut(ctx, cancel, pokemonStream)
 	if err != nil {
-		return err
-	}
-
-	for i, p := range pokemons {
-		urls := strings.Split(p.FlatAbilityURLs, "|")
-		var abilities []string
-		for _, url := range urls {
-			ability, err := r.FetchAbility(url)
-			if err != nil {
-				return err
-			}
-
-			for _, ee := range ability.EffectEntries {
-				abilities = append(abilities, ee.Effect)
-			}
-		}
-
-		pokemons[i].EffectEntries = abilities
+		return fmt.Errorf("cannot refresh pokemons due to err: %v", err)
 	}
 
 	if err := r.Save(ctx, pokemons); err != nil {
-		return err
+		return fmt.Errorf("cannot save in cache pokemons due to err: %v", err)
 	}
 
 	return nil
+}
+
+func (r Refresher) fanOut(ctx context.Context, cancel context.CancelFunc, in chan models.Pokemon) ([]models.Pokemon, error) {
+	var pokemons []models.Pokemon
+	wg := sync.WaitGroup{}
+
+	for pokemon := range in {
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("cannot continue reading pokemon stream from id: %d, due to err: %v", pokemon.ID, ctx.Err())
+		}
+
+		wg.Add(1)
+		go func(pokemon models.Pokemon) {
+			defer wg.Done()
+
+			if ctx.Err() != nil {
+				log.Printf("breaking goroutine (#%d) process due to invalid context: %v\n", pokemon.ID, ctx.Err())
+				return
+			}
+
+			urls := strings.Split(pokemon.FlatAbilityURLs, "|")
+			var abilities []string
+			for _, url := range urls {
+				ability, err := r.FetchAbility(url)
+				if err != nil {
+					log.Printf("cannot fetch ability for: %d, due to err: %v\n", pokemon.ID, err)
+					cancel()
+					return
+				}
+
+				for _, ee := range ability.EffectEntries {
+					abilities = append(abilities, ee.Effect)
+				}
+			}
+
+			pokemon.EffectEntries = abilities
+			pokemons = append(pokemons, pokemon)
+		}(pokemon)
+	}
+
+	wg.Wait()
+
+	return pokemons, nil
 }


### PR DESCRIPTION
### Enhancement to time processing of `api/provide` endpoint:

| `api/provide        ` |  10 records | 20 records | 100 records | 500 records     |
| -------------------- | ------------ | ------------ | ------------- | --------------- |
| main                      | 2.98 secs    | 5.99 secs    | 32.43 secs    | 2m 33.66 secs |
| enhancemente      |  357 ms      | 364 ms       | 494 ms         | 5.65 secs        |


### Enhancement of time processing of `api/refresh-cache` endpoint:

| `api/refresh-cache` |  10 records | 20 records | 100 records |
| -------------------- | ------------ | ------------ | ------------- |
| main                      | 4.27  secs   | 10.61 secs   | 58.69 secs   |
| enhancemente      |  603 ms      | 1541 ms      | 2.90 secs     |

